### PR TITLE
Added CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.23)
+
+project(Arduino-Library-PCA9546A LANGUAGES C CXX ASM)
+
+add_library(arduino_PCA9546A STATIC
+  ${CMAKE_CURRENT_LIST_DIR}/src/PCA9546A.cpp
+)
+
+target_include_directories(arduino_PCA9546A
+  PUBLIC
+  ${CMAKE_CURRENT_LIST_DIR}/src
+)


### PR DESCRIPTION
Added CMake support declaring a static library (arduino_PCA9546A)

This library will need to be linked with the Arduino Core and Arduino Wire libraries